### PR TITLE
pageserver: fix records_committed metric

### DIFF
--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -21,6 +21,7 @@ use tracing::*;
 use walkdir::WalkDir;
 
 use crate::context::RequestContext;
+use crate::metrics::WAL_INGEST;
 use crate::pgdatadir_mapping::*;
 use crate::tenant::remote_timeline_client::INITDB_PATH;
 use crate::tenant::Timeline;
@@ -319,6 +320,8 @@ async fn import_wal(
                 walingest
                     .ingest_record(recdata, lsn, &mut modification, &mut decoded, ctx)
                     .await?;
+                WAL_INGEST.records_committed.inc();
+
                 modification.commit(ctx).await?;
                 last_lsn = lsn;
 


### PR DESCRIPTION
A small fix to https://github.com/neondatabase/neon/pull/5886 to correct this metric: because the incremetn was moved out of the ingest_record function, it needs calling in the other places we call ingest_record.